### PR TITLE
Make Docker API version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Application Options:
   -s, --service= services to report [$SERVICES]  
       --concurrency= number of concurrent requests to services (default: 4) [$CONCURRENCY]
       --timeout= timeout for each request to services (default: 5s) [$TIMEOUT]
-      --docker-api=  docker API version (default: 1.24) [$DOCKER_API]
+      --docker-api= docker API version (default: 1.24) [$DOCKER_API]
       --dbg     show debug info [$DEBUG]
 
 Help Options:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Application Options:
   -v, --volume= volumes to report (default: root:/) [$VOLUMES]
   -s, --service= services to report [$SERVICES]  
       --concurrency= number of concurrent requests to services (default: 4) [$CONCURRENCY]
-      --timeout= timeout for each request to services (default: 5s) [$TIMEOUT] 
+      --timeout= timeout for each request to services (default: 5s) [$TIMEOUT]
+      --docker-api=  docker API version (default: 1.24) [$DOCKER_API]
       --dbg     show debug info [$DEBUG]
 
 Help Options:
@@ -44,6 +45,7 @@ Help Options:
 * services (`--service`, can be repeated) is a list of name:url pairs, where name is a name of the service, and url is a url to the service. Supports `http`, `https`, `mongodb` and `docker` schemes. The response for each service will be in `services` field.
 * concurrency (`--concurrency`) is a number of concurrent requests to services.
 * timeout (`--timeout`) is a timeout for each request to services.
+* docker-api (`--docker-api`) is a docker engine API version. The default is `1.24`, which works with Docker 1.12+. For newer Docker engines that dropped support for older API versions (e.g., Docker 28+ requires at least `1.44`), set this to the minimum supported version.
 * config file (`--config`, `-f`) is a path to the config file, see below for details.
 
 ## configuration file 
@@ -624,6 +626,7 @@ services:
       - LISTEN=0.0.0.0:8080
       - VOLUMES=home:/hosthome,root:/hostroot
       - SERVICES=health:http://172.17.42.1/health,docker:docker:///var/run/docker.sock
+      # - DOCKER_API=1.44  # set for Docker 28+ which requires API version 1.44+
 
 ```
 

--- a/app/main.go
+++ b/app/main.go
@@ -32,8 +32,9 @@ var opts struct {
 	Services []string      `short:"s" long:"service" env:"SERVICES" env-delim:"," description:"services to report"`
 	TimeOut  time.Duration `long:"timeout" env:"TIMEOUT" default:"5s" description:"timeout for each request to services"`
 
-	Concurrency int  `long:"concurrency" env:"CONCURRENCY" default:"4" description:"number of concurrent requests to services"`
-	Dbg         bool `long:"dbg" env:"DEBUG" description:"show debug info"`
+	Concurrency      int    `long:"concurrency" env:"CONCURRENCY" default:"4" description:"number of concurrent requests to services"`
+	DockerAPIVersion string `long:"docker-api" env:"DOCKER_API" default:"1.24" description:"docker API version"`
+	Dbg              bool   `long:"dbg" env:"DEBUG" description:"show debug info"`
 }
 
 func main() {
@@ -85,7 +86,7 @@ func main() {
 	providers := external.Providers{
 		HTTP:        &external.HTTPProvider{Client: http.Client{Timeout: opts.TimeOut}},
 		Mongo:       &external.MongoProvider{TimeOut: opts.TimeOut},
-		Docker:      &external.DockerProvider{TimeOut: opts.TimeOut},
+		Docker:      &external.DockerProvider{TimeOut: opts.TimeOut, APIVersion: opts.DockerAPIVersion},
 		Program:     &external.ProgramProvider{TimeOut: opts.TimeOut, WithShell: true},
 		Nginx:       &external.NginxProvider{TimeOut: opts.TimeOut},
 		Certificate: &external.CertificateProvider{TimeOut: opts.TimeOut},

--- a/app/status/external/docker_provider.go
+++ b/app/status/external/docker_provider.go
@@ -13,11 +13,10 @@ import (
 	"time"
 )
 
-const dockerClientVersion = "1.24"
-
 // DockerProvider is a status provider that uses docker
 type DockerProvider struct {
-	TimeOut time.Duration
+	TimeOut    time.Duration
+	APIVersion string // docker API version, default "1.24"
 }
 
 // Status the url looks like: docker:///var/run/docker.sock or docker://1.2.3.4:2375
@@ -48,7 +47,11 @@ func (d *DockerProvider) Status(req Request) (*Response, error) {
 		Timeout: d.TimeOut,
 	}
 
-	dkURL := fmt.Sprintf("http://localhost/v%s/containers/json", dockerClientVersion)
+	apiVersion := d.APIVersion
+	if apiVersion == "" {
+		apiVersion = "1.24"
+	}
+	dkURL := fmt.Sprintf("http://localhost/v%s/containers/json", apiVersion)
 	resp, err := client.Get(dkURL)
 	if err != nil {
 		return nil, fmt.Errorf("docker request failed: %s %s: %w", req.Name, req.URL, err)

--- a/app/status/external/docker_provider_test.go
+++ b/app/status/external/docker_provider_test.go
@@ -17,7 +17,7 @@ func TestDockerProvider_Status(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, "/v1.24/containers/json", r.URL.Path)
+				assert.Equal(t, "/v1.22/containers/json", r.URL.Path)
 				time.Sleep(time.Millisecond * 10)
 				w.WriteHeader(http.StatusOK)
 				data, err := os.ReadFile("testdata/containers.json")
@@ -28,8 +28,9 @@ func TestDockerProvider_Status(t *testing.T) {
 			},
 		),
 	)
+	defer ts.Close()
 
-	p := DockerProvider{TimeOut: time.Second}
+	p := DockerProvider{TimeOut: time.Second, APIVersion: "1.22"}
 	resp, err := p.Status(Request{Name: "d1", URL: strings.Replace(ts.URL, "http://", "tcp://", 1)})
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -40,7 +41,7 @@ func TestDockerProvider_StatusWithRequired(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, "/v1.24/containers/json", r.URL.Path)
+				assert.Equal(t, "/v1.22/containers/json", r.URL.Path)
 				time.Sleep(time.Millisecond * 10)
 				w.WriteHeader(http.StatusOK)
 				data, err := os.ReadFile("testdata/containers.json")
@@ -51,8 +52,9 @@ func TestDockerProvider_StatusWithRequired(t *testing.T) {
 			},
 		),
 	)
+	defer ts.Close()
 
-	p := DockerProvider{TimeOut: time.Second}
+	p := DockerProvider{TimeOut: time.Second, APIVersion: "1.22"}
 
 	{
 		resp, err := p.Status(
@@ -69,6 +71,27 @@ func TestDockerProvider_StatusWithRequired(t *testing.T) {
 		assert.Equal(t, 200, resp.StatusCode)
 		assert.Equal(t, "ok", resp.Body["required"])
 	}
+}
+
+func TestDockerProvider_StatusDefaultAPIVersion(t *testing.T) {
+	ts := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/v1.24/containers/json", r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+				data, err := os.ReadFile("testdata/containers.json")
+				assert.NoError(t, err)
+				_, e := w.Write(data)
+				assert.NoError(t, e)
+			},
+		),
+	)
+	defer ts.Close()
+
+	p := DockerProvider{TimeOut: time.Second} // no APIVersion set, should default to "1.24"
+	resp, err := p.Status(Request{Name: "d1", URL: strings.Replace(ts.URL, "http://", "tcp://", 1)})
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
 }
 
 func TestDockerProvider_parseDockerResponse(t *testing.T) {


### PR DESCRIPTION
The Docker provider hardcodes API version `1.24` (Docker Engine 1.12 era). Newer Docker engines (28+, e.g. on Ubuntu 24.04) dropped support for API versions below `1.44`, causing `sys-agent` to fail with *"client version 1.24 is too old"* when querying `/v1.24/containers/json`.

**Changes:**
- Replace hardcoded `dockerClientVersion` constant with configurable `APIVersion` field on `DockerProvider`
- Add `--docker-api` CLI flag / `DOCKER_API` env var (default `1.24`)
- Wire the option from CLI through to the provider
- Add `defer ts.Close()` to all Docker test httptest servers
- Document the new option in README (usage block, parameters, docker-compose example)